### PR TITLE
feature: allow requiring select captures for output to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
  
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.0] - 2025-01-12
+
+Adds ability to require specified captures to have at least one match in order for output to show for a given line:
+
+```
+-r, --require <REQUIRE>          Name of capture that must have at least one match for the output to show. Can be specified multiple times
+```
+
 ## [0.1.0] - 2025-01-11
 
 First release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "grits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = """
 A text line processor that applies regular expressions with named captures
 to input lines and transforms them using a user-generated template.
 """
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 readme = "README.md"
 license = "MIT"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -165,7 +165,12 @@ pub struct Cli {
     /// Input files
     pub files: Vec<String>,
 
-    /// Force output to be line-buffered.  By default, output is line buffered when stdout is a
+    /// Name of capture that must have at least one match for the output to show. Can be specified
+    /// multiple times
+    #[arg(short, long)]
+    pub require: Vec<String>,
+
+    /// Force output to be line-buffered. By default, output is line buffered when stdout is a
     /// terminal and block-buffered otherwise
     #[arg(long)]
     pub line_buffered: bool,


### PR DESCRIPTION
Adds ability to require specified captures to have at least one match in order for output to show for a given line:

```
-r, --require <REQUIRE>          Name of capture that must have at least one match for the output to show. Can be specified multiple times
```
