### PR TITLE
feature: remove '$' requirement to start anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following example demonstrates how to apply `grits` to `tcpdump` to extract 
 sudo tcpdump -nn | grits -p '^(?<ts>[^ ]+)' \
   -p 'IP\w? (?<src>[^ ]+)' \
   -p '> (?<dst>[^ ]+):' \
-  -t '[${(cyan|bold):ts}] ${(green|underlined):"src"}=${src} ${(yellow|underlined):"dst"}=${dst}'
+  -t '[{(cyan|bold):ts}] {(green|underlined):"src"}={src} {(yellow|underlined):"dst"}={dst}'
 ```
 
 ![demo image](images/demo.png)
@@ -85,17 +85,17 @@ Check the [releases page](https://github.com/solidiquis/grits/releases) for preb
 ## Templating language
 
 `grits` uses a simple templating language to transform text, where templates consist of anchors.
-Anchors are placeholders enclosed within `${...}` that correspond to named capture groups from
+Anchors are placeholders enclosed within `{...}` that correspond to named capture groups from
 the regular expression applied to the input. Once a match is found, the value from the
 capture group is inserted into the anchor’s position in the template string.
 
 Here's an example:
 ```bash
-echo 'level=info msg=foobar path=/baz' | grit -p 'msg=(?<log>[^ ]+)' -o 'transformed=${log}'
+echo 'level=info msg=foobar path=/baz' | grit -p 'msg=(?<log>[^ ]+)' -t 'transformed={log}'
 ```
 
 In this command, we use a regular expression to capture the value associated with the msg field.
-The capture group is named `log`. The template string `transformed=${log}` will replace `${log}` with
+The capture group is named `log`. The template string `transformed={log}` will replace `{log}` with
 the value captured from the input. The output will then be:
 
 ```
@@ -104,7 +104,7 @@ transformed=foobar
 
 To summarize:
 - The regular expression `msg=(?<log>[^ ]+)` captures the value `foobar` into the `log` capture group.
-- The template `transformed=${log}` uses the value of `log` to generate the output.
+- The template `transformed={log}` uses the value of `log` to generate the output.
 
 The following are additional features of `grits` templating system:
 
@@ -116,7 +116,7 @@ immediately after the anchor name.  For example, to access the second match of t
 capture group, you would use:
 
 ```
-${log[1]}
+{log[1]}
 ```
 
 ### Default values
@@ -125,7 +125,7 @@ If a particular anchor doesn't have an associated match, default values can be c
 operator like so:
 
 ```
-${log || foo || bar[1] || "NO MATCH"}
+{log || foo || bar[1] || "NO MATCH"}
 ```
 
 The first default value that doesn't produce a blank string will be used. Default values can be
@@ -136,14 +136,14 @@ other anchors or a string literal.
 Attributes offer additional means to transform text. Attributes are applied to anchors like so:
 
 ```
-${(red|bold):ipaddr_v4}
+{(red|bold):ipaddr_v4}
 ```
 
 Here is an example using attributes with default values:
 
 
 ```
-${(red|bold):ipaddr_v4 || ipaddr_v6 || "NOMATCH"}
+{(red|bold):ipaddr_v4 || ipaddr_v6 || "NOMATCH"}
 ```
 
 In the above example, `red` and `bold` will be applied the entire anchor.
@@ -177,13 +177,13 @@ The following attributes are currently available:
 1. Multi-file processing:
 
 ```bash
-grits -p 'sysctl=(?<sysctl>.*)'` -p 'sysctl output: ${sysctl}' file1 file2
+grits -p 'sysctl=(?<sysctl>.*)'` -t 'sysctl output: {sysctl}' file1 file2
 ```
 
 2. Piping:
 
 ```bash
-docker logs -f 93670ea0964c | grits -p 'log_level=info(?<log>.*)' -o 'INFO LOG: ${log}'
+docker logs -f 93670ea0964c | grits -p 'log_level=info(?<log>.*)' -t 'INFO LOG: {log}'
 ```
 
 3. Attributes, default values, and multiple regular expressions:
@@ -192,10 +192,10 @@ docker logs -f 93670ea0964c | grits -p 'log_level=info(?<log>.*)' -o 'INFO LOG: 
 kubectl logs -f -n foo -l app=bar | grits \
      -p '^kernel:(?<kern>.*)' \
      -p '^sysctl:(?<sys>.*)' \
-     -o kernel=${(cyan):kern || \"NONE\"} sysctl=${(magenta):sys || \"NONE\"}
+     -t 'kernel={(cyan):kern || \"NONE\"} sysctl={(magenta):sys || \"NONE\"}'
 ```
 
-### Completions
+## Completions
 
 Completions for supported shells can be generated using `grits --completions <SHELl>`. Consult your shell's documentation
 for how to setup completions. For `zsh`, completions are bootstrapped like so:
@@ -203,6 +203,11 @@ for how to setup completions. For `zsh`, completions are bootstrapped like so:
 ```bash
 grits --completions zsh > ~/.oh-my-zsh/completions/_grits
 ```
+
+## Colorization
+
+`grits` follows the informal [NO_COLOR](https://no-color.org/) standard. Setting `NO_COLOR` to a non-blank value will disable output colorization.
+If stdout is not a terminal, colorization is automatically disabled.
 
 ## Contributing
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,11 +37,11 @@ memory:
 The remaining memory is stored in a capture called 'mem'. Now to transform the input line into
 our desired output, we'll use the following template string:
 
-    Remaining memory: ${mem}
+    Remaining memory: {mem}
 
 Putting everything together the following command:
 
-    $ echo $LINE | grits -p 'Memory: (?<mem>[^ ]+)' -o 'Remaining memory: ${mem}'
+    $ echo $LINE | grits -p 'Memory: (?<mem>[^ ]+)' -o 'Remaining memory: {mem}'
 
 Gets us the following output:
 
@@ -58,7 +58,7 @@ Colorization is disabled under two circumstances:
 
 An example of how to disable color:
 
-    $ NO_COLOR=1 grits -p 'Memory: (?<mem>[^ ]+)' -o 'Remaining memory: ${mem}' file
+    $ NO_COLOR=1 grits -p 'Memory: (?<mem>[^ ]+)' -o 'Remaining memory: {mem}' file
 
 ------------------------
 ----OUTPUT TEMPLATE-----
@@ -67,14 +67,14 @@ The output template which is specified using `-o, --output-template` is a format
 that defines how to transform a line input and ultimately produce an output. The output
 template contains constructs called anchors which looks like the following:
     
-    ${log}
+    {log}
 
-This anchor, which begins with '$' and ends with '}', is a reference to a named capture
+This anchor, which begins with '{' and ends with '}', is a reference to a named capture
 from a regular expression that a user provides. If, for a given input line, there is a
 match for the `log` capture, then the value associated with the `log` capture will be used
 to interpolate the output string at the `log` anchor. For example:
 
-    $ echo 'level=info msg=foobar path=/baz' | grit -p 'msg=(?<log>[^ ]+)' -o 'transformed=${log}'
+    $ echo 'level=info msg=foobar path=/baz' | grit -p 'msg=(?<log>[^ ]+)' -o 'transformed={log}'
 
 Will get you the following output:
 
@@ -89,19 +89,19 @@ Anchors come with a handful of other features as well:
 2. Chain default values, which can be another anchor or a string literal. The first non-blank
 value will be used in the output (ultimately falls back to an empty string):
 
-    ${log || foo || bar[1] || \"NO MATCH\"}
+    {log || foo || bar[1] || \"NO MATCH\"}
 
 3. Apply to an anchor like so:
 
-    ${(red|bold):foo}
+    {(red|bold):foo}
 
 4. Apply ANSI-escape sequences to literals:
 
-    ${(cyan|underlined):\"foo\"}
+    {(cyan|underlined):\"foo\"}
 
-5. Escape characters with special meaning such as '$' with '\\':
+5. Escape characters with special meaning such as '{' with '\\':
 
-    USD: \\$${amount}
+    USD: \\{foo\\} {amount}
 
 ----------------
 ---ATTRIBUTES---
@@ -109,7 +109,7 @@ value will be used in the output (ultimately falls back to an empty string):
 As mentioned in the section prior, attributes are available to stylize the result of processing
 the anchors. Multiple attributes may be used together like so:
 
-    ${(red|bold|underlined):foo}
+    {(red|bold|underlined):foo}
 
 The following attributes are currently available:
 
@@ -139,18 +139,18 @@ The following attributes are currently available:
 ----------------
 1. Multi-file processing:
 
-    $ grits -p 'sysctl=(?<sysctl>.*)'` -p 'sysctl output: ${sysctl}' file1 file2
+    $ grits -p 'sysctl=(?<sysctl>.*)'` -p 'sysctl output: {sysctl}' file1 file2
 
 2. Piping:
 
-    $ docker logs -f 93670ea0964c | grits -p 'log_level=info(?<log>.*)' -o 'INFO LOG: ${log}'
+    $ docker logs -f 93670ea0964c | grits -p 'log_level=info(?<log>.*)' -o 'INFO LOG: {log}'
 
 3. Attributes, default values, and multiple regular expressions:
 
     $ kubectl logs -f -n foo -l app=bar | grits \\
          -p '^kernel:(?<kern>.*)' \\
          -p '^sysctl:(?<sys>.*)' \\
-         -o kernel=${(cyan):kern || \"NONE\"} sysctl=${(magenta):sys || \"NONE\"}
+         -o kernel=${(cyan):kern || \"NONE\"} sysctl={(magenta):sys || \"NONE\"}
 "
 )]
 pub struct Cli {

--- a/src/template/error.rs
+++ b/src/template/error.rs
@@ -1,6 +1,6 @@
 use super::{
     parse::rules::VALID_ANCHOR_CHARSET,
-    token::{ANCHOR, ANCHOR_CLOSE, ANCHOR_OPEN, ATTRIBUTE_CLOSE, ATTRIBUTE_END, ESCAPE},
+    token::{ANCHOR_CLOSE, ATTRIBUTE_CLOSE, ATTRIBUTE_END, ESCAPE},
 };
 use indoc::{formatdoc, indoc};
 use std::fmt::{self, Display};
@@ -45,14 +45,6 @@ impl ParseError {
             char_index,
             partial_template: chars.iter().collect(),
             message: format!("A character immediately following the '{ESCAPE}' escape is required."),
-        }
-    }
-
-    pub fn invalid_anchor_start(char_index: usize, chars: &[char]) -> Self {
-        ParseError {
-            char_index,
-            partial_template: chars.iter().collect(),
-            message: format!("Expected '{ANCHOR_OPEN}' to immediately follow '{ANCHOR}'."),
         }
     }
 

--- a/src/template/parse/test.rs
+++ b/src/template/parse/test.rs
@@ -2,89 +2,83 @@ use super::{attr::Attribute, parse, DefaultValue};
 
 #[test]
 fn test_parse_plain() {
-    let template_string = "output=${log}";
+    let template_string = "output={log}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
 
     let anchor = &anchors[0];
     assert_eq!(&anchor.name, "log");
-    assert_eq!(anchor.start, 7);
-    assert_eq!(anchor.end, 13);
+    assert_eq!("{log}", &template_string[anchor.start..anchor.end]);
     assert_eq!(anchor.index, None);
 }
 
 #[test]
 fn test_parse_plain_whitespace() {
-    let template_string = "\toutput=${\tlog\n}   ";
+    let template_string = "\toutput={\tlog\n}   ";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
     let anchor = &anchors[0];
     assert_eq!(&anchor.name, "log");
-    assert_eq!(anchor.start, 8);
-    assert_eq!(anchor.end, 16);
+    assert_eq!("{\tlog\n}", &template_string[anchor.start..anchor.end]);
     assert_eq!(anchor.index, None);
 }
 
 #[test]
 fn test_parse_escape() {
-    let template_string = r"\$ output=${log}";
+    let template_string = r"\$ output={log}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
 
     let anchor = &anchors[0];
     assert_eq!(&anchor.name, "log");
-    assert_eq!(anchor.start, 10);
-    assert_eq!(anchor.end, 16);
+    assert_eq!("{log}", &template_string[anchor.start..anchor.end]);
     assert_eq!(anchor.index, None);
 
-    let template_string = r"\$ \\ output=${log}";
+    let template_string = r"\$ \\ output={log}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
 
     let anchor = &anchors[0];
     assert_eq!(&anchor.name, "log");
-    assert_eq!(anchor.start, 13);
-    assert_eq!(anchor.end, 19);
+    assert_eq!("{log}", &template_string[anchor.start..anchor.end]);
     assert_eq!(anchor.index, None);
 }
 
 #[test]
 fn test_parse_index() {
-    let template_string = "primary=${log[0]} secondary=${log[102]}";
+    let template_string = "primary={log[0]} secondary={log[102]}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 2);
 
     let anchor = &anchors[0];
     assert_eq!(&anchor.name, "log");
-    assert_eq!(anchor.start, 8);
-    assert_eq!(anchor.end, 17);
+    assert_eq!("{log[0]}", &template_string[anchor.start..anchor.end]);
     assert_eq!(anchor.index, Some(0));
 
     let anchor = &anchors[1];
     assert_eq!(&anchor.name, "log");
-    assert_eq!(anchor.start, 28);
-    assert_eq!(anchor.end, 39);
+    assert_eq!("{log[102]}", &template_string[anchor.start..anchor.end]);
     assert_eq!(anchor.index, Some(102));
 }
 
 #[test]
 fn test_parse_index_errors() {
-    let template_string = "primary=${[0]}";
+    let template_string = "primary={[0]}";
     let anchors = parse(template_string);
     assert!(anchors.is_err_and(|e| e.to_string().contains("Invalid index operation")));
 
-    let template_string = "primary=${  \t  [0]}";
+    let template_string = "primary={  \t  [0]}";
     let anchors = parse(template_string);
     assert!(anchors.is_err_and(|e| e.to_string().contains("Invalid index operation")));
 
-    let template_string = "primary=${foobar [0]}";
+    let template_string = "primary={foobar [0]}";
     let anchors = parse(template_string);
     assert!(anchors.is_err_and(|e| e.to_string().contains("Invalid index operation")));
 }
 
 #[test]
 fn test_default_literal_parse_single_value() {
-    let template_string = "primary=${foo || 'bar'}";
+    let template_string = "primary={foo || 'bar'}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
 
@@ -99,7 +93,7 @@ fn test_default_literal_parse_single_value() {
 
 #[test]
 fn test_default_literal_parse_multi_value() {
-    let template_string = "primary=${foo || 'bar' || 'baz'}";
+    let template_string = "primary={foo || 'bar' || 'baz'}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
 
@@ -118,11 +112,11 @@ fn test_default_literal_parse_multi_value() {
 
 #[test]
 fn test_default_anchor() {
-    let template_string = "primary=${foo||bar}";
+    let template_string = "primary={foo||bar}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
     let anchor = &anchors[0];
-    assert_eq!("${foo||bar}", &template_string[anchor.start..anchor.end]);
+    assert_eq!("{foo||bar}", &template_string[anchor.start..anchor.end]);
     let default_values = &anchor.defaults;
     assert_eq!(default_values.len(), 1);
     let DefaultValue::Anchor { name, index } = &default_values[0] else {
@@ -134,11 +128,11 @@ fn test_default_anchor() {
 
 #[test]
 fn test_default_anchor_whitespace() {
-    let template_string = "primary=${foo || bar}";
+    let template_string = "primary={foo || bar}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
     let anchor = &anchors[0];
-    assert_eq!("${foo || bar}", &template_string[anchor.start..anchor.end]);
+    assert_eq!("{foo || bar}", &template_string[anchor.start..anchor.end]);
 
     let default_values = &anchor.defaults;
     assert_eq!(default_values.len(), 1);
@@ -151,11 +145,11 @@ fn test_default_anchor_whitespace() {
 
 #[test]
 fn test_default_anchor_indexes() {
-    let template_string = "primary=${foo || bar[0]}";
+    let template_string = "primary={foo || bar[0]}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
     let anchor = &anchors[0];
-    assert_eq!("${foo || bar[0]}", &template_string[anchor.start..anchor.end]);
+    assert_eq!("{foo || bar[0]}", &template_string[anchor.start..anchor.end]);
 
     let default_values = &anchor.defaults;
     assert_eq!(default_values.len(), 1);
@@ -168,11 +162,11 @@ fn test_default_anchor_indexes() {
 
 #[test]
 fn test_default_anchor_multi_value() {
-    let template_string = "primary=${foo || bar || baz}";
+    let template_string = "primary={foo || bar || baz}";
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
     let anchor = &anchors[0];
-    assert_eq!("${foo || bar || baz}", &template_string[anchor.start..anchor.end]);
+    assert_eq!("{foo || bar || baz}", &template_string[anchor.start..anchor.end]);
 
     let default_values = &anchor.defaults;
     assert_eq!(default_values.len(), 2);
@@ -188,12 +182,12 @@ fn test_default_anchor_multi_value() {
 
 #[test]
 fn test_default_values_multi_value_with_indexes() {
-    let template_string = r#"primary=${foo[3] || bar[0] || "baz"}"#;
+    let template_string = r#"primary={foo[3] || bar[0] || "baz"}"#;
     let anchors = parse(template_string).unwrap();
     assert_eq!(anchors.len(), 1);
     let anchor = &anchors[0];
     assert_eq!(
-        "${foo[3] || bar[0] || \"baz\"}",
+        "{foo[3] || bar[0] || \"baz\"}",
         &template_string[anchor.start..anchor.end]
     );
 
@@ -216,17 +210,17 @@ fn test_default_values_multi_value_with_indexes() {
 
 #[test]
 fn test_attribute() {
-    let template_string = "output=${(red|bold):foo}";
+    let template_string = "output={(red|bold):foo}";
     let anchors = parse(template_string).unwrap();
     let anchor = &anchors[0];
-    assert_eq!("${(red|bold):foo}", &template_string[anchor.start..anchor.end]);
+    assert_eq!("{(red|bold):foo}", &template_string[anchor.start..anchor.end]);
     assert!(anchor.attributes.iter().find(|a| a == &&Attribute::Red).is_some());
     assert!(anchor.attributes.iter().find(|a| a == &&Attribute::Bold).is_some());
 }
 
 #[test]
 fn test_literal_anchor() {
-    let template_string = r#"output=${"foo"}"#;
+    let template_string = r#"output={"foo"}"#;
     let anchors = parse(template_string).unwrap();
     let anchor = &anchors[0];
     assert!(anchor.name.is_empty());
@@ -239,10 +233,7 @@ fn test_literal_anchor() {
 
 #[test]
 fn test_literal_anchor_with_attributes() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
-    let template_string = r#"output=${(red|bold):"foo"}"#;
+    let template_string = r#"output={(red|bold):"foo"}"#;
     let anchors = parse(template_string).unwrap();
     let anchor = &anchors[0];
     assert!(anchor.name.is_empty());
@@ -253,7 +244,7 @@ fn test_literal_anchor_with_attributes() {
     assert_eq!(val, "foo");
     assert!(anchor.attributes.len() > 0);
 
-    assert_eq!("${(red|bold):\"foo\"}", &template_string[anchor.start..anchor.end]);
+    assert_eq!("{(red|bold):\"foo\"}", &template_string[anchor.start..anchor.end]);
     assert!(anchor.attributes.iter().find(|a| a == &&Attribute::Red).is_some());
     assert!(anchor.attributes.iter().find(|a| a == &&Attribute::Bold).is_some());
 }

--- a/src/template/test.rs
+++ b/src/template/test.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 #[test]
 fn test_output_template_basic() {
-    let template = "log=${foo} out=${bar} baz";
+    let template = "log={foo} out={bar} baz";
     let out = OutputTemplate::parse(template).unwrap();
     assert_eq!(out.targets.len(), 5);
 
@@ -17,7 +17,7 @@ fn test_output_template_basic() {
 
 #[test]
 fn test_output_template_no_match() {
-    let template = "log=${foo} out=${bar} baz";
+    let template = "log={foo} out={bar} baz";
     let out = OutputTemplate::parse(template).unwrap();
     assert_eq!(out.targets.len(), 5);
 
@@ -30,7 +30,7 @@ fn test_output_template_no_match() {
 
 #[test]
 fn test_output_template_default() {
-    let template = r#"log=${foo} out=${bar || "foobaz"} baz"#;
+    let template = r#"log={foo} out={bar || "foobaz"} baz"#;
     let out = OutputTemplate::parse(template).unwrap();
     assert_eq!(out.targets.len(), 5);
 
@@ -43,7 +43,7 @@ fn test_output_template_default() {
 
 #[test]
 fn test_output_template_indexes() {
-    let template = r#"log=${foo} out=${bar[1]}"#;
+    let template = r#"log={foo} out={bar[1]}"#;
     let out = OutputTemplate::parse(template).unwrap();
     assert_eq!(out.targets.len(), 4);
 
@@ -56,7 +56,7 @@ fn test_output_template_indexes() {
 }
 #[test]
 fn test_output_template_indexes_and_defaults() {
-    let template = r#"${foo[1]||bar[1]}"#;
+    let template = r#"{foo[1]||bar[1]}"#;
     let out = OutputTemplate::parse(template).unwrap();
     println!("{out:?}");
     assert_eq!(out.targets.len(), 1);
@@ -71,7 +71,7 @@ fn test_output_template_indexes_and_defaults() {
 
 #[test]
 fn test_output_template_attributes() {
-    let template = r#"${(red|bold):foo[1]||bar[1]}"#;
+    let template = r#"{(red|bold):foo[1]||bar[1]}"#;
     let out = OutputTemplate::parse(template).unwrap();
     println!("{out:?}");
     assert_eq!(out.targets.len(), 1);

--- a/src/template/token.rs
+++ b/src/template/token.rs
@@ -1,5 +1,4 @@
 pub const ESCAPE: char = '\\';
-pub const ANCHOR: char = '$';
 pub const ANCHOR_OPEN: char = '{';
 pub const ANCHOR_CLOSE: char = '}';
 pub const INDEX_OPEN: char = '[';


### PR DESCRIPTION
## Changes

- Changes anchor declaration from `${...}` to `{...}`.
- Using the `$` syntax prevents users from using double-quoted Bash strings because of conflicts with parameter expansion and Bash string-interpolation.
- Now users can use double-quoted bash strings and use Bash string interpolation and parameter expansion within the template string.
- Edited README + CLI help text.
